### PR TITLE
Add an explicit check for the fio command.

### DIFF
--- a/storage-benchmark
+++ b/storage-benchmark
@@ -96,6 +96,23 @@ then
     exit 1
 fi
 
+
+if [ ! -x /usr/bin/fio ]
+then
+  echo "This benchmark requires the 'fio' command be installed"
+  echo "Would you like to install it?"
+  read INSTALLFIO
+  if [[ ! $INSTALLFIO =~ ^[Yy]$ ]]
+    then
+    	echo "** cancelled **"
+    	exit 1
+    else
+    	echo "** Installing fio **"
+    	yum install -y fio
+    fi
+fi
+
+
 echo ""
 echo "**** WARNING! We recommend you stop all Satellite 6 services to ensure no "
 echo "interruption to critical processes."


### PR DESCRIPTION
Because the user may not have the `fio` command installed. 