### PR TITLE
add the '-p' option to the mkdir  command

### DIFF
--- a/storage-benchmark
+++ b/storage-benchmark
@@ -30,7 +30,7 @@
 set -e
 
 testlocation(){
-  mkdir $TESTDIRECTORY
+  mkdir -p $TESTDIRECTORY
   echo ""
   echo "Starting IO tests via the 'fio' command. This may take up to an hour or more"
   echo "depending on the size of the files being tested. Be patient!"


### PR DESCRIPTION
Otherwise the script fails with `mkdir: cannot create directory ‘/var/lib/pulp//storage-benchmark’: File exists` in the event the testing directory already exists. If the directory already exists, mkdir should 'noop' and we should just use the existing directory. 