### PR TITLE
Only install rpms if they are actually missing

### DIFF
--- a/satellite-reset
+++ b/satellite-reset
@@ -42,7 +42,14 @@ truncatetasks(){
 cancelpulptasks(){
   emessage "Install pulp-admin"
   pulpversion=$(rpm -qa pulp-server --queryformat "%{VERSION}")
-  yum -y install pulp-admin-client-${pulpversion} pulp-rpm-admin-extensions.noarch pulp-rpm-handlers.noarch
+  # 6.3:
+  # allrpms="pulp-admin-client-${pulpversion} pulp-rpm-admin-extensions.noarch pulp-rpm-handlers.noarch"
+  # 6.4:
+  allrpms="pulp-admin-client-${pulpversion} pulp-rpm-admin-extensions.noarch"
+  for myrpm in ${allrpms}
+  do
+    rpm -q --quiet ${myrpm}||yum -y install ${myrpm}
+  done
 
   sed -i.bak "20,30s/^# host:.*/host: $(hostname -f)/g" /etc/pulp/admin/admin.conf
   mkdir -p ~/.pulp

--- a/satellite-reset
+++ b/satellite-reset
@@ -60,7 +60,7 @@ cancelpulptasks(){
   do
     rpm -q --quiet ${myrpm}  
     if [ $? -eq 1 ]; then 
-      emessage "Installing ${myrpm}"
+      emessage "RPM ${myrpm} is missing! Installing..."
       yum -y install ${myrpm}
     else
       emessage "RPM ${myrpm} already installed"

--- a/satellite-reset
+++ b/satellite-reset
@@ -42,10 +42,18 @@ truncatetasks(){
 cancelpulptasks(){
   emessage "Install pulp-admin"
   pulpversion=$(rpm -qa pulp-server --queryformat "%{VERSION}")
-  # 6.3:
-  # allrpms="pulp-admin-client-${pulpversion} pulp-rpm-admin-extensions.noarch pulp-rpm-handlers.noarch"
-  # 6.4:
-  allrpms="pulp-admin-client-${pulpversion} pulp-rpm-admin-extensions.noarch"
+  satversion=$(rpm -q satellite --queryformat "%{VERSION}")
+  case ${satversion} in
+    6.3.*)
+      allrpms="pulp-admin-client-${pulpversion} pulp-rpm-admin-extensions.noarch pulp-rpm-handlers.noarch"
+      ;;
+    6.4.*)
+      allrpms="pulp-admin-client-${pulpversion} pulp-rpm-admin-extensions.noarch"
+      ;;
+    *)
+      allrpms="pulp-admin-client-${pulpversion}"
+      ;;
+   esac
   for myrpm in ${allrpms}
   do
     rpm -q --quiet ${myrpm}||yum -y install ${myrpm}

--- a/satellite-reset
+++ b/satellite-reset
@@ -40,9 +40,10 @@ truncatetasks(){
 
 ### 2. Cancel all pulp tasks
 cancelpulptasks(){
-  emessage "Install pulp-admin"
+
   pulpversion=$(rpm -qa pulp-server --queryformat "%{VERSION}")
   satversion=$(rpm -q satellite --queryformat "%{VERSION}")
+
   case ${satversion} in
     6.3.*)
       allrpms="pulp-admin-client-${pulpversion} pulp-rpm-admin-extensions.noarch pulp-rpm-handlers.noarch"
@@ -54,9 +55,16 @@ cancelpulptasks(){
       allrpms="pulp-admin-client-${pulpversion}"
       ;;
    esac
+  #
   for myrpm in ${allrpms}
   do
-    rpm -q --quiet ${myrpm}||yum -y install ${myrpm}
+    rpm -q --quiet ${myrpm}  
+    if [ $? -eq 1 ]; then 
+      emessage "Installing ${myrpm}"
+      yum -y install ${myrpm}
+    else
+      emessage "RPM ${myrpm} already installed"
+    fi
   done
 
   sed -i.bak "20,30s/^# host:.*/host: $(hostname -f)/g" /etc/pulp/admin/admin.conf
@@ -65,9 +73,12 @@ cancelpulptasks(){
   sudo cat /etc/pki/katello/certs/pulp-client.crt /etc/pki/katello/private/pulp-client.key > ~/.pulp/user-cert.pem
 
   NUMTASKS=`mongo pulp_database --eval 'printjson(db.task_status.find({"state": {"$in": ["waiting", "running"]}}).toArray())' | grep task_id | awk '{print $NF}' | sed s#\"##g | sed s#,##g | wc -l`
-  emessage "Cancelling [$NUMTASKS] Pulp Tasks"
-  mongo pulp_database --eval 'printjson(db.task_status.find({"state": {"$in": ["waiting", "running"]}}).toArray())' | grep task_id | awk '{print $NF}' | sed s#\"##g | sed s#,##g | xargs -n1 pulp-admin tasks  cancel --task-id
-
+  if [ $NUMTASKS -eq 0 ]; then
+    emessage "No tasks to cancel ( $NUMTASKS Pulp Tasks Found!)"
+  else
+    emessage "Cancelling [$NUMTASKS] Pulp Tasks"
+    mongo pulp_database --eval 'printjson(db.task_status.find({"state": {"$in": ["waiting", "running"]}}).toArray())' | grep task_id | awk '{print $NF}' | sed s#\"##g | sed s#,##g | xargs -n1 pulp-admin tasks  cancel --task-id
+  fi
   emessage "Pulp Task Cancel: Complete"
 }
 


### PR DESCRIPTION
Hi,
Due to BZ https://bugzilla.redhat.com/show_bug.cgi?id=1625649 it makes it a pain that satellite-reset tries to install rpms even if it doesn't need to. This minor change makes the script try to run 'yum install' only if it is not presently installed.
Of course, I had to change the all_rpms list because it didn't work for satellite 6.4.
Please let me know if you'd like me to rework this that that the allrpms list is in a 'case' statement.
Thank you,
Vincent