### PR TITLE
Updated to log_min_duration_statement to (5s)

### DIFF
--- a/tuning-profiles/custom-hiera-2ex-large-256G.yaml
+++ b/tuning-profiles/custom-hiera-2ex-large-256G.yaml
@@ -25,7 +25,7 @@ postgresql::server::config_entries:
   checkpoint_completion_target: 0.9
   effective_cache_size: 32GB
   autovacuum_vacuum_cost_limit: 2000
-  log_min_duration_statement: 500
+  log_min_duration_statement: 5000
 
 
 # Manual configurations recommended:

--- a/tuning-profiles/custom-hiera-ex-large-128G.yaml
+++ b/tuning-profiles/custom-hiera-ex-large-128G.yaml
@@ -25,7 +25,7 @@ postgresql::server::config_entries:
   checkpoint_completion_target: 0.9
   effective_cache_size: 32GB
   autovacuum_vacuum_cost_limit: 2000
-  log_min_duration_statement: 500
+  log_min_duration_statement: 5000
 
 
 # Manual configurations recommended:

--- a/tuning-profiles/custom-hiera-large-64G.yaml
+++ b/tuning-profiles/custom-hiera-large-64G.yaml
@@ -23,7 +23,7 @@ postgresql::server::config_entries:
   checkpoint_completion_target: 0.9
   effective_cache_size: 16GB
   autovacuum_vacuum_cost_limit: 2000
-  log_min_duration_statement: 500
+  log_min_duration_statement: 5000
 
 # Manual configurations recommended:
 #

--- a/tuning-profiles/custom-hiera-medium-32G.yaml
+++ b/tuning-profiles/custom-hiera-medium-32G.yaml
@@ -17,7 +17,7 @@ postgresql::server::config_entries:
   checkpoint_completion_target: 0.9
   effective_cache_size: 16GB
   autovacuum_vacuum_cost_limit: 2000
-  log_min_duration_statement: 500
+  log_min_duration_statement: 5000
 
 # Manual configurations recommended:
 #


### PR DESCRIPTION
Even though I understand that a SQL query which is taking more than 0.5 seconds to run probably should be considered a slow query. the scope of this profile, however, is to provide some **performance** guidelines and to have this parameter set to `500` is too aggressive. 

`log_min_duration_statement` is not enabled by default and since the idea of the tuning profile is not to **debug**, we should keep this value at least within a reasonable scope, which can trigger bad results for large customers which might have a busy Satellite.

Made it the default to 5 seconds (5000).  