### PR TITLE
report long queries from PostgreSQL (#51)

### DIFF
--- a/postgres-activity-report.sh
+++ b/postgres-activity-report.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+cd ~postgres
+
+echo ""
+
+PGQUERY="SELECT pid, age(clock_timestamp(), query_start), usename AS dbname, query FROM pg_stat_activity ORDER BY query_start desc;"
+
+echo $PGQUERY | sudo -u postgres psql -d foreman


### PR DESCRIPTION
It would be nice to view which queries in PG is running for a very long time as shown below 
~~~
  pid  |           age           |  dbname   |                                                                                                                                                                                                                                                                                                  query                                                                                                                                                                                                                                                                                                  
-------+-------------------------+-----------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 20231 | 00:00:00.002464         | postgres  | SELECT pid, age(clock_timestamp(), query_start), usename AS dbname, query FROM pg_stat_activity ORDER BY query_start desc;
  3183 | 00:00:00.489057         | foreman   | SELECT  "katello_events".* FROM "katello_events" WHERE ("katello_events"."process_after" IS NULL OR "katello_events"."process_after" BETWEEN $1 AND $2) AND "katello_events"."in_progress" = $3 ORDER BY "katello_events"."created_at" ASC LIMIT $4
  2898 | 00:00:00.63192          | candlepin | COMMIT
 20004 | 00:00:00.635672         | candlepin | COMMIT
 19457 | 00:00:00.636122         | candlepin | COMMIT
 31055 | 00:00:01.124658         | foreman   | COMMIT
  3092 | 00:00:04.872539         | foreman   | COMMIT
  2900 | 00:00:05.635551         | candlepin | COMMIT
  3103 | 00:00:12.880121         | foreman   | SELECT * FROM "dynflow_delayed_plans" WHERE ((start_at <= '2019-12-25 11:28:12.764953+0000' OR (start_before IS NOT NULL AND start_before <= '2019-12-25 11:28:12.764953+0000')) AND ("frozen" IS FALSE)) ORDER BY "start_at"
  3184 | 00:00:13.885232         | foreman   | UPDATE "dynflow_coordinator_records" SET "id" = 'c14f20e0-b0dd-4bf6-b8e1-4054c3192d77', "class" = 'Dynflow::Coordinator::ExecutorWorld', "owner_id" = NULL, "data" = '{"class":"Dynflow::Coordinator::ExecutorWorld","id":"c14f20e0-b0dd-4bf6-b8e1-4054c3192d77","meta":{"hostname":"dhcp131-68.gsslab.pnq2.redhat.com","pid":2699,"queues":{"default":{"pool_size":5},"remote_execution":{"pool_size":5}},"last_seen":"2019-12-25 16:58:11.758","delayed_executor":true},"active":true}' WHERE (("class" = 'Dynflow::Coordinator::ExecutorWorld') AND ("id" = 'c14f20e0-b0dd-4bf6-b8e1-4054c3192d77'))
 31048 | 00:00:23.449863         | foreman   | COMMIT
 18193 | 00:02:00.498653         | candlepin | 
 19458 | 00:02:00.498951         | candlepin | 
 19860 | 00:02:00.499116         | candlepin | 
  3336 | 00:03:25.638289         | candlepin | COMMIT
 31051 | 03:22:54.185231         | foreman   | LISTEN "world:8c20fc44-8b34-4abf-ac27-c2804408d192"
  2899 | 10:58:25.625911         | candlepin | COMMIT
  3335 | 10:58:25.628423         | candlepin | COMMIT
  3104 | 12 days 00:40:29.990717 | foreman   | LISTEN "world:c14f20e0-b0dd-4bf6-b8e1-4054c3192d77"

~~~