### PR TITLE
Don't error out if foreman-maintain isn't installed.

### DIFF
--- a/storage-benchmark
+++ b/storage-benchmark
@@ -114,7 +114,6 @@ then
     fi
 fi
 
-
 echo ""
 echo "**** WARNING! We recommend you stop all Satellite 6 services to ensure no "
 echo "interruption to critical processes."
@@ -124,20 +123,28 @@ echo "Do you wish to stop Satellite 6 services? (Y/N) "
 read STOPSERVICES
 if [[ $STOPSERVICES =~ ^[Yy]$ ]]
 then
-    echo ""
-    echo "Stopping services."
-    echo ""
-    foreman-maintain service stop
+    if ! [ -x "$(command -v foreman-maintain)" ]; then
+        echo "foreman-maintain not installed. Continuing."
+    else
+        echo ""
+        echo "Stopping services."
+        echo ""
+        foreman-maintain service stop
+    fi
 fi
 
 testlocation
 
 if [[ $STOPSERVICES =~ ^[Yy]$ ]]
 then
-    echo ""
-    echo "Starting services."
-    echo ""
-    foreman-maintain service start
+    if ! [ -x "$(command -v foreman-maintain)" ]; then
+        echo "foreman-maintain not installed. Continuing."
+    else
+        echo ""
+        echo "Starting services."
+        echo ""
+        foreman-maintain service start
+    fi
 fi
 
 echo "Finished."


### PR DESCRIPTION
This is useful for pre-testing on a host without Satellite