### PR TITLE
Clarify storage-benchmark expectations in README

### DIFF
--- a/storage-benchmark
+++ b/storage-benchmark
@@ -18,9 +18,10 @@
 #
 # https://access.redhat.com/solutions/3397771
 #
-# Generally you wish to see on average 100MB/sec or higher in the tests below.
-#  - Local SSD based storage should values of 600MB/sec or higher
-#  - Spinning disks should see values in the range of 100-200MB/sec or higher
+# Generally you wish to see on average 100MB/sec or higher in the READ test.
+#  - Local SSD based storage should values of 600MB/sec or higher.
+#  - Spinning disks should see values in the range of 100-200MB/sec or higher.
+#  - Note that the random READ/WRITE results are expected to be much slower.
 #  - If you see values below this, please open a support ticket for assistance.
 #
 ###############################################################################


### PR DESCRIPTION
This is to make it more clear, as it is in the linked KCS, that the expectation is specifically for the sequential READ test, while random READ/WRITE is expected to be many times slower.