### PR TITLE
Check CDN ips

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 Tools for use in supporting the operation of Satellite 6
 
 ##### Tools
-- [check-perf-tuning](#check-perf-tuning)  
-- [check-cdn-ips] (#check-cdn-ips)
+- [check-perf-tuning](#check-perf-tuning) 
+- [check-cdn-ips](#check-cdn-ips)
 - [mongo-benchmark](#mongo-benchmark)  
 - [mongo-size-report](#mongo-size-report)  
 - [postgres-monitor](#postgres-monitor)  

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@ Tools for use in supporting the operation of Satellite 6
 
 ##### Tools
 - [check-perf-tuning](#check-perf-tuning)  
+- [check-cdn-ips] (#check-cdn-ips)
 - [mongo-benchmark](#mongo-benchmark)  
 - [mongo-size-report](#mongo-size-report)  
 - [postgres-monitor](#postgres-monitor)  
@@ -17,6 +18,10 @@ Tools for use in supporting the operation of Satellite 6
 ## [check-perf-tuning](check-perf-tuning)
 
 Utility to check performance tuning parameters on your Satellite 6 server.
+
+## [check-cdn-ips](check-cdn-ips)
+
+Utility to check if Satellite has access to a list of ips.
 
 ## [mongo-benchmark](mongo-benchmark)
 

--- a/check-cdn-ips.py
+++ b/check-cdn-ips.py
@@ -1,0 +1,85 @@
+#!/bin/python
+
+import socket
+import argparse
+import sys
+import re
+try:
+    import requests
+except ImportError:
+    print('Please install the python-requests module.')
+    sys.exit(-1)
+
+output = ([],[])
+
+def get_json(url):
+    # Performs a GET using the passed URL location
+  try:
+    r = requests.get(url, timeout=15, verify=args.verify)
+    r = r.json()
+    ip_list = []
+    for x in r['cidr_list']:
+        ip = re.search('\d+.\d+.\d+.\d+', x['ip_prefix'])
+        ip_list.append(ip.group())
+  except ValueError:
+    print  ("Json was not returned. Not Good!")
+    sys.exit()
+  return ip_list
+
+def target_path(path):
+    print(path)
+    ip_list = []
+    ip = open(path)
+    try:
+        for x in ip:
+            x = re.search('\d+.\d+.\d+.\d+', x)
+            ip_list.append(x.group())
+    finally:
+        ip.close()
+    return ip_list
+
+def scan(target):
+    print('\n' + ' Starting Scan For ' + str(target))
+    scan_ip(target, args.port, args.timeout)
+
+def scan_ip(ipaddress, port, timeout):
+    socket.setdefaulttimeout(timeout)
+    try:
+        sock = socket.socket()
+        sock.connect((ipaddress, port))
+        print("[ + ] Access " + str(ipaddress))
+        output[0].append(str(ipaddress))
+        sock.close()
+    except:
+        print("[ - ] Denied " + str(ipaddress))
+        output[1].append(str(ipaddress))
+        pass
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(prog='PROG')
+    parser.add_argument("--verify", default=False, help="Ignore untrusted CA")
+    parser.add_argument("--timeout", type=int, default=1, help="Port timeout")
+    parser.add_argument("--port", type=int, default=443, help="What port to scan against")
+    parser.add_argument("--api", default="https://access.redhat.com/sites/default/files/cdn_redhat_com_cac.json", help="URL for API Call. Default is https://access.redhat.com/sites/default/files/cdn_redhat_com_cac.json")
+    parser.add_argument("--path", default=None, help="Use file, if API is blocked. Use full path to file.")
+    args = parser.parse_args()
+ 
+    if args.path is not None:
+        targets = target_path(args.path)
+        for x in targets:
+            if x != '':
+                scan(x)
+        print ('----------Access----------')
+        print (output[0])
+        print ('----------Denied----------')
+        print (output[1])
+    else:
+        print (args.api)
+        targets = get_json(args.api)
+        for x in targets:
+            if x != '':
+                scan(x)
+        print ('----------Access----------')
+        print (output[0])
+        print ('----------Denied----------')
+        print (output[1])


### PR DESCRIPTION
This will allow a user to check if a list of IPS is accessible from a server without using nmap, or nc. Instead, the script will use the socket library. Some clients do not allow admins to install port scanning. Therefore, a work around was needed. 