### PR TITLE
Avoid using 'ps | sort' by using 'ps --sort' in process-monitor.sh

### DIFF
--- a/process-monitor.sh
+++ b/process-monitor.sh
@@ -2,7 +2,7 @@
 while :
     do
         date >> process-monitor-output.log
-        ps -aux | sort -rnk6 >> process-monitor-output.log
+        ps -aux --sort="-rss" >> process-monitor-output.log
         echo "" >> process-monitor-output.log
         echo "" >> process-monitor-output.log
         sleep 10


### PR DESCRIPTION
Not incredibly important; just avoiding a needless pipe in process-monitor.sh. :-)