### PR TITLE
storage-benchmark: Force LANG to avoid errors in floating point printf

### DIFF
--- a/storage-benchmark
+++ b/storage-benchmark
@@ -30,6 +30,9 @@
 # Exit on any error
 set -e
 
+# Ensure memory math works as expected - rif. bug #80
+export LANG=C
+
 testlocation(){
   mkdir -p $TESTDIRECTORY
   echo ""


### PR DESCRIPTION
Force LANG to avoid errors in floating point printf for memory rounding.

fix issue #80