### PR TITLE
Script updated to avoid issues when running in the customer environment

### DIFF
--- a/postgres-size-report
+++ b/postgres-size-report
@@ -33,23 +33,20 @@ cd ~postgres
 echo ""
 echo "************* Candlepin Tablesizes *************"
 echo ""
-echo $TABLEQUERY | sudo -u postgres psql -d candlepin
-
+echo $TABLEQUERY | su - postgres -c "psql candlepin"
 
 echo ""
 echo "************** Foreman Tablesizes **************"
 echo ""
-echo $TABLEQUERY | sudo -u postgres psql -d foreman
+echo $TABLEQUERY | su - postgres -c "psql foreman"
 
-
-if PULPCORE_TABLESIZES=$(echo $TABLEQUERY | sudo -u postgres psql -d pulpcore 2>/dev/null)
+if PULPCORE_TABLESIZES=$(echo $TABLEQUERY | su - postgres -c "psql pulpcore" 2>/dev/null)
 then
   echo ""
   echo "************** Pulpcore Tablesizes *************"
   echo ""
   echo "$PULPCORE_TABLESIZES"
 fi
-
 
 echo ""
 echo "*************** FileSystem Usage ***************"


### PR DESCRIPTION
I'm facing a lot of customers issue when running this script, because of the `sudo` command. At the end of the day, changing the script locally as proposed here works like a charm.

That said, we are basically changing the command structure, but the result will be the expected one.

From
```
echo $TABLEQUERY | sudo -u postgres psql -d candlepin
```

To
```
echo $TABLEQUERY | su - postgres -c "psql candlepin"
```