### PR TITLE
- Fixes #81: yum install does not work for fio.

### DIFF
--- a/storage-benchmark
+++ b/storage-benchmark
@@ -111,7 +111,7 @@ then
     	exit 1
     else
     	echo "** Installing fio **"
-    	yum install -y fio
+    	foreman-maintain packages install fio
     fi
 fi
 


### PR DESCRIPTION
-       yum install -y fio
+       foreman-maintain packages install fio

Since on Satellite we lock packages, please use foreman-maintain packages install fio instead of yum install -y fio in storage-benchmark's
